### PR TITLE
Ошибки на получение jwt-токена

### DIFF
--- a/finam_trade_api/assets/model.py
+++ b/finam_trade_api/assets/model.py
@@ -68,7 +68,7 @@ class AssetResponse(BaseAssetModel):
     decimals: int
     min_step: str
     lot_size: FinamDecimal
-    expiration_date: str | None = None
+    expiration_date: FinamDate | None = None
     quote_currency: str
 
 


### PR DESCRIPTION
Посыпались ошибки на получение jwt-токена
Token is invalid or malformed. See: https://api.finam.ru/docs/rest/#authservice_auth

В методах set_jwt_token, get_jwt_token_details в заголовке передается параметр self._auth_headers. Финам считает его лишним и отбивает такие запросы.
Необходимо убрать Authorization из запросов получения токена и информации о нём.